### PR TITLE
Add support of passing Kafka header when producing

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -76,6 +77,11 @@ type Header struct {
 	Value []byte
 }
 
+type Plugin interface {
+	OnProduce(ctx context.Context, path string, peer string, injector func(key, value string) error)
+	OnConsume(ctx context.Context, path string, injector func(key string) (string, error))
+}
+
 type KaproxyClient struct {
 	host  string
 	port  int
@@ -85,6 +91,11 @@ type KaproxyClient struct {
 
 	httpCli         *http.Client
 	httpBlockingCli *http.Client //For blocking request only
+	plugins         []Plugin
+}
+
+func (c *KaproxyClient) Use(plugin Plugin) {
+	c.plugins = append(c.plugins, plugin)
 }
 
 func NewKaproxyClient(host string, port int, token string) *KaproxyClient {
@@ -149,11 +160,22 @@ func (c *KaproxyClient) buildRequest(method, path string, query url.Values, body
 	}
 	targetUrl := url.URL{
 		Scheme:   "http",
-		Host:     fmt.Sprintf("%s:%d", c.host, c.port),
+		Host:     c.genHost(c.host, c.port),
 		Path:     path,
 		RawQuery: query.Encode(),
 	}
 	return http.NewRequest(method, targetUrl.String(), body)
+}
+
+func (c *KaproxyClient) genProducePath(topic string, partition int) string {
+	var path string
+
+	if partition >= 0 {
+		path = fmt.Sprintf("/topic/%s/partition/%d", topic, partition)
+	} else {
+		path = fmt.Sprintf("/topic/%s", topic)
+	}
+	return path
 }
 
 func (c *KaproxyClient) produce(topic string, partition int, message Message, hash bool) (*ProduceResp, *APIError) {
@@ -167,15 +189,10 @@ func (c *KaproxyClient) produce(topic string, partition int, message Message, ha
 		res, _ := json.Marshal(message.Headers)
 		body.Add("headers", string(res))
 	}
-	if partition >= 0 {
-		path = fmt.Sprintf("/topic/%s/partition/%d", topic, partition)
-	} else {
-		path = fmt.Sprintf("/topic/%s", topic)
-		if hash {
-			body.Add("partitioner", "hash")
-		}
+	path = c.genProducePath(topic, partition)
+	if partition < 0 && hash {
+		body.Add("partitioner", "hash")
 	}
-
 	req, err := c.buildRequest(http.MethodPost, path, nil, strings.NewReader(body.Encode()))
 	if err != nil {
 		return nil, &APIError{requestErr, err.Error(), ""}
@@ -208,61 +225,72 @@ func (c *KaproxyClient) Produce(topic string, message Message) (*ProduceResp, *A
 	return c.produce(topic, -1, message, false)
 }
 
+func (c *KaproxyClient) genHost(host string, port int) string {
+	return fmt.Sprintf("%s:%d", host, port)
+}
+
+func (c *KaproxyClient) onProduce(ctx context.Context, topic string, partition int, message *Message) {
+	for _, plugin := range c.plugins {
+		plugin.OnProduce(ctx, c.genProducePath(topic, partition), c.genHost(c.host, c.port), func(key, value string) error {
+			message.Headers = append(message.Headers, Header{[]byte(key), []byte(value)})
+			return nil
+		})
+	}
+}
+
+func (c *KaproxyClient) onBatchProduce(ctx context.Context, topic string, messages *[]Message) {
+	for _, plugin := range c.plugins {
+		plugin.OnProduce(ctx, c.genBatchProducePath(topic), c.genHost(c.host, c.port), func(key, value string) error {
+			for i, message := range *messages {
+				(*messages)[i].Headers = append(message.Headers, Header{[]byte(key), []byte(value)})
+			}
+			return nil
+		})
+	}
+}
+func (c *KaproxyClient) ProduceWithCtx(ctx context.Context, topic string, message Message) (*ProduceResp, *APIError) {
+	c.onProduce(ctx, topic, -1, &message)
+	return c.Produce(topic, message)
+
+}
 func (c *KaproxyClient) ProduceWithHash(topic string, message Message) (*ProduceResp, *APIError) {
 	return c.produce(topic, -1, message, true)
+}
+
+func (c *KaproxyClient) ProduceWithHashWithCtx(ctx context.Context, topic string, message Message) (*ProduceResp, *APIError) {
+	c.onProduce(ctx, topic, -1, &message)
+	return c.ProduceWithHash(topic, message)
 }
 
 func (c *KaproxyClient) ProduceWithPartition(topic string, partition int, message Message) (*ProduceResp, *APIError) {
 	return c.produce(topic, partition, message, false)
 }
 
-func (c *KaproxyClient) BatchProduceWithJson(topic string, messages []Message) (int, *APIError) {
-	requestBodyBytes, err := json.Marshal(messages)
-	if err != nil {
-		return 0, &APIError{requestErr, err.Error(), ""}
-	}
-	req, err := c.buildRequest(http.MethodPost, fmt.Sprintf("/topic/%s/batch_with_json", topic), nil, bytes.NewBuffer(requestBodyBytes))
-	if err != nil {
-		return 0, &APIError{requestErr, err.Error(), ""}
-	}
-	req.Header.Add("Content-Type", "application/json; charset=utf-8")
-	resp, err := c.httpCli.Do(req)
-	if err != nil {
-		return 0, &APIError{requestErr, err.Error(), ""}
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return 0, &APIError{requestErr, parseResponseError(resp), resp.Header.Get(rid)}
-	}
-
-	respBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return 0, &APIError{responseErr, err.Error(), resp.Header.Get(rid)}
-	}
-
-	var respData struct {
-		Count int `json:"count"`
-	}
-	err = json.Unmarshal(respBytes, &respData)
-	if err != nil {
-		return 0, &APIError{responseErr, err.Error(), resp.Header.Get(rid)}
-	}
-	return respData.Count, nil
+func (c *KaproxyClient) ProduceWithPartitionWithCtx(ctx context.Context, topic string, partition int, message Message) (*ProduceResp, *APIError) {
+	c.onProduce(ctx, topic, partition, &message)
+	return c.ProduceWithPartition(topic, partition, message)
 }
 
 func (c *KaproxyClient) BatchProduce(topic string, messages []Message) (int, *APIError) {
 	body := new(bytes.Buffer)
 	multiform := multipart.NewWriter(body)
-	for _, message := range messages {
+	var headerSlice = make([][]Header, len(messages))
+	for i, message := range messages {
 		multiform.WriteField(string(message.Key), string(message.Value))
+		headerSlice[i] = message.Headers
 	}
 	multiform.Close()
-	req, err := c.buildRequest(http.MethodPost, fmt.Sprintf("/topic/%s/batch", topic), nil, body)
+	req, err := c.buildRequest(http.MethodPost, c.genBatchProducePath(topic), nil, body)
 	if err != nil {
 		return 0, &APIError{requestErr, err.Error(), ""}
 	}
 	req.Header.Add("Content-Type", fmt.Sprintf("multipart/form-data; charset=utf-8; boundary=%s", multiform.Boundary()))
+	if headerStore, err := json.Marshal(headerSlice); err == nil {
+		req.Header.Add("__headers__", string(headerStore))
+	} else {
+		return 0, &APIError{requestErr, err.Error(), ""}
+	}
+
 	resp, err := c.httpCli.Do(req)
 	if err != nil {
 		return 0, &APIError{requestErr, err.Error(), ""}
@@ -288,6 +316,18 @@ func (c *KaproxyClient) BatchProduce(topic string, messages []Message) (int, *AP
 	return respData.Count, nil
 }
 
+func (c *KaproxyClient) genBatchProducePath(topic string) string {
+	return fmt.Sprintf("/topic/%s/batch", topic)
+}
+
+func (c *KaproxyClient) BatchProduceWithCtx(ctx context.Context, topic string, messages []Message) (int, *APIError) {
+	c.onBatchProduce(ctx, topic, &messages)
+	return c.BatchProduce(topic, messages)
+}
+
+func (c *KaproxyClient) genConsumePath(group string, topic string) string {
+	return fmt.Sprintf("/group/%s/topic/%s", group, topic)
+}
 func (c *KaproxyClient) Consume(group, topic string, durationArg ...time.Duration) (*ConsumeResp, *APIError) {
 	timeout := 3000 * time.Millisecond //blocking timeout
 	if len(durationArg) > 0 {
@@ -299,7 +339,7 @@ func (c *KaproxyClient) Consume(group, topic string, durationArg ...time.Duratio
 		ttr := durationArg[1]
 		query.Add("ttr", strconv.FormatInt(ttr.Nanoseconds()/1000000, 10))
 	}
-	req, err := c.buildRequest(http.MethodGet, fmt.Sprintf("/group/%s/topic/%s", group, topic), query, nil)
+	req, err := c.buildRequest(http.MethodGet, c.genConsumePath(group, topic), query, nil)
 	if err != nil {
 		return nil, &APIError{requestErr, err.Error(), ""}
 	}
@@ -341,6 +381,23 @@ func (c *KaproxyClient) Consume(group, topic string, durationArg ...time.Duratio
 		return nil, &APIError{responseErr, err.Error(), resp.Header.Get(rid)}
 	}
 	return &respData, nil
+}
+
+func (c *KaproxyClient) ConsumeWithCtx(ctx context.Context, group, topic string, durationArg ...time.Duration) (*ConsumeResp, *APIError) {
+	consumeResp, err := c.Consume(group, topic, durationArg...)
+	if consumeResp != nil {
+		for _, plugin := range c.plugins {
+			plugin.OnConsume(ctx, c.genConsumePath(topic, group), func(key string) (string, error) {
+				for _, header := range consumeResp.Headers {
+					if string(header.Key) == key {
+						return string(header.Value), nil
+					}
+				}
+				return "", nil
+			})
+		}
+	}
+	return consumeResp, err
 }
 
 func (c *KaproxyClient) ACK(group, topic string, message *ConsumeResp) *APIError {

--- a/conf/kaproxy-default.toml
+++ b/conf/kaproxy-default.toml
@@ -9,7 +9,7 @@ AccessLogEnable = false
 
 [Kafka]
 Brokers = ["127.0.0.1:9092"]
-Version = "0.8.2.2"
+Version = "1.1.0"
 Zookeepers = ["127.0.0.1:2181"]
 ZKSessionTimeout = "6s"
 

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -68,11 +68,12 @@ func GetFnvHash(key string) int32 {
 	return int32(hash.Sum32() >> 1) // Right shit to avoid converting to negative value
 }
 
-func (p *Producer) ProduceMessageWithoutReplication(topic, key, value string, partition int32) (*ProduceResponse, error) {
+func (p *Producer) ProduceMessageWithoutReplication(topic, key, value string, recordHeader []sarama.RecordHeader, partition int32) (*ProduceResponse, error) {
 	msg := &sarama.ProducerMessage{
 		Topic:     topic,
 		Value:     sarama.StringEncoder(value),
 		Partition: partition,
+		Headers:   recordHeader,
 	}
 	if key != "" {
 		msg.Key = sarama.StringEncoder(key)
@@ -89,11 +90,12 @@ func (p *Producer) ProduceMessageWithoutReplication(topic, key, value string, pa
 	return response, nil
 }
 
-func (p *Producer) ProduceMessageWithReplication(topic, key, value string, partition int32, partitionMethod string) (*ProduceResponse, error) {
+func (p *Producer) ProduceMessageWithReplication(topic, key, value string, recordHeader []sarama.RecordHeader, partition int32, partitionMethod string) (*ProduceResponse, error) {
 	msg := &sarama.ProducerMessage{
 		Topic:     topic,
 		Value:     sarama.StringEncoder(value),
 		Partition: partition,
+		Headers:   recordHeader,
 	}
 	if key != "" {
 		msg.Key = sarama.StringEncoder(key)
@@ -107,6 +109,7 @@ func (p *Producer) ProduceMessageWithReplication(topic, key, value string, parti
 			Topic:           topic,
 			Key:             []byte(key),
 			Value:           []byte(value),
+			Headers:         recordHeader,
 			Partition:       partition,
 			PartitionMethod: partitionMethod,
 		}

--- a/server/consumer_handler.go
+++ b/server/consumer_handler.go
@@ -26,6 +26,8 @@ func reply(c *gin.Context, message *sarama.ConsumerMessage) {
 		c.JSON(http.StatusOK, gin.H{
 			"key":       string(message.Key),
 			"value":     string(message.Value),
+			"headers":   message.Headers,
+			"timestamp": message.Timestamp,
 			"topic":     message.Topic,
 			"partition": message.Partition,
 			"offset":    message.Offset,
@@ -35,6 +37,8 @@ func reply(c *gin.Context, message *sarama.ConsumerMessage) {
 		c.JSON(http.StatusOK, gin.H{
 			"key":       string(message.Key),
 			"value":     message.Value,
+			"headers":   message.Headers,
+			"timestamp": message.Timestamp,
 			"topic":     message.Topic,
 			"partition": message.Partition,
 			"offset":    message.Offset,

--- a/server/route.go
+++ b/server/route.go
@@ -57,6 +57,5 @@ func setupProxyRouters(engine *gin.Engine) {
 		produceAPI.POST("", metrics.TrackHttpMetrics("produce"), produceByPartitioner)
 		produceAPI.POST("/partition/:partition", metrics.TrackHttpMetrics("produce"), produceManual)
 		produceAPI.POST("/batch", metrics.TrackHttpMetrics("batch_produce"), batchProduce)
-		produceAPI.POST("/batch_with_json", metrics.TrackHttpMetrics("batch_produce"), batchProduceWithJson)
 	}
 }

--- a/server/route.go
+++ b/server/route.go
@@ -57,5 +57,6 @@ func setupProxyRouters(engine *gin.Engine) {
 		produceAPI.POST("", metrics.TrackHttpMetrics("produce"), produceByPartitioner)
 		produceAPI.POST("/partition/:partition", metrics.TrackHttpMetrics("produce"), produceManual)
 		produceAPI.POST("/batch", metrics.TrackHttpMetrics("batch_produce"), batchProduce)
+		produceAPI.POST("/batch_with_json", metrics.TrackHttpMetrics("batch_produce"), batchProduceWithJson)
 	}
 }


### PR DESCRIPTION
Support Kafka header passthrough, which can be used to transmit trace ID.